### PR TITLE
Fix crash on --medvram/--lowvram

### DIFF
--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -127,6 +127,7 @@ class Script(scripts.Script):
             du_state_dict = torch.load(model, map_location='cpu')
 
           network, info = lora_compvis.create_network_and_apply_compvis(du_state_dict, weight, text_encoder, unet)
+          network.to(p.sd_model.device, dtype=p.sd_model.dtype)
           print(f"LoRA model {model} loaded: {info}")
           self.latest_networks.append((network, model))
       if len(self.latest_networks) > 0:


### PR DESCRIPTION
Trying to use the extension with --medvram or --lowvram results in following crash:
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat2 in method wrapper_mm)`
As per https://rentry.org/HDGLoRaIssues, there is a one-line fix to that problem. Tested loading the model and generating a picture on ROCm with both --medvram and --lowvram, and it works fine. Figured it's better to contribute it to upstream.