### PR TITLE
Make LoRA config reproducable via models folder in extension path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+models/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 - Jan 6 2023, 2023/1/6: 
   - Fixed a bug that broke the model were broken when switching enable->disable->enable...
-  - SD 2.xのモデルで有効・無効を繰り返し切り替えるとモデルが壊れていく不具合を修正しました。
+  - SD 2.x のモデルで有効・無効を繰り返し切り替えるとモデルが壊れていく不具合を修正しました。
 - Jan 5 2023, 2023/1/5: 
   - Added folder icon for easy LoRA selection. Fixed negative weights are not working.
   - ファイル選択ダイアログを開くアイコンを追加しました。負の重みを設定しても動かない不具合を修正しました。
 - Jan 2 2023, 2023/1/2: 
   - Added support for SD2.x (training scripts has been supported before.) Added error checking to prevent crashes.
-  - SD2.Xへのサポートを追加しました（学習用スクリプトは以前から対応済みです）。拡張が落ちないように事前のエラーチェックを追加しました。
+  - SD2.X へのサポートを追加しました（学習用スクリプトは以前から対応済みです）。拡張が落ちないように事前のエラーチェックを追加しました。
 
 ## About
 
@@ -34,11 +34,15 @@ Other networks other than LoRA may be supported in the future.
 
 ## How to use
 
+Put the LoRA models (`*.pt`, `*.ckpt` or `*.safetensors`) inside the `sd-webui-additional-networks/models/LoRA` folder.
+
 Open __"Additional Networks"__ panel from the left bottom of Web UI.
+
+Press __"Refresh models"__ to update the models list.
 
 Select __"LoRA"__ for __"Network module 1"__.
 
-Enter __the full path of LoRA model file__ (*.ckpt or *.safetensors) in __"Model 1"__.
+Choose __the name of the LoRA model file__ in __"Model 1"__.
 
 Set __the weight__ of the model (negative weight might be working but unexpected.)
 
@@ -46,34 +50,38 @@ Repeat them for the module/model/weight 2 to 5 if you have other models. Models 
 
 You can generate images with the model with these additional networks.
 
-## このWeb UI拡張について
+## この Web UI 拡張について
 
-LoRAなどのネットワークを元のStable Diffusionに追加し、画像生成を行うための拡張です。現在はLoRAのみ対応しています。
+LoRA などのネットワークを元の Stable Diffusion に追加し、画像生成を行うための拡張です。現在は LoRA のみ対応しています。
 
-この拡張で使えるのは[sd-scripts](https://github.com/kohya-ss/sd-scripts)リポジトリで学習したLoRAのモデル（\*.ckpt または \*.safetensors）です。他のLoRAリポジトリで学習したモデルは対応していません。
+この拡張で使えるのは[sd-scripts](https://github.com/kohya-ss/sd-scripts)リポジトリで学習した LoRA のモデル（\*.ckpt または \*.safetensors）です。他の LoRA リポジトリで学習したモデルは対応していません。
 
 この拡張単体では学習はできません。
 
-将来的にLoRA以外のネットワークについてもサポートするかもしれません。
+将来的に LoRA 以外のネットワークについてもサポートするかもしれません。
 
 ## インストール
 
-1. Web UIで "Extensions" タブを開きます。
+1. Web UI で "Extensions" タブを開きます。
 1. さらに "Install from URL" タブを開きます。
-1. "URL for extension's git repository" 欄にこのリポジトリのURLを入れます。
+1. "URL for extension's git repository" 欄にこのリポジトリの URL を入れます。
 1. "Install"ボタンを押してインストールします。
-1. Web UIを再起動してください。
+1. Web UI を再起動してください。
 
 ## 使用法
 
-Web UIの左下のほうの __"Additional Networks"__ のパネルを開きます。
+学習した LoRA のモデル(`*.pt`, `*.ckpt`, `*.safetensors`)を`sd-webui-additional-networks/models/LoRA`に置きます。
+
+Web UI の左下のほうの __"Additional Networks"__ のパネルを開きます。
 
 __"Network module 1"__ で __"LoRA"__ を選択してください。
 
-__"Model 1"__ に学習したLoRAのモデルファイルを __フルパス（ドライブ名やディレクトリ名付き）で__ 入力します。
+__"Refresh models"__ で LoRA モデルのリストを更新します。
+
+__"Model 1"__ に学習した LoRA のモデル名を選択します。
 
 __"Weight"__ にこのモデルの __重み__ を指定します（負の値も指定できますがどんな効果があるかは未知数です）。
 
-追加のモデルがある場合は2～5に指定してください。モデルは1~5の順番で適用されます。
+追加のモデルがある場合は 2～5 に指定してください。モデルは 1~5 の順番で適用されます。
 
 以上を指定すると、それぞれのモデルが適用された状態で画像生成されます。

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -15,20 +15,22 @@ from scripts import lora_compvis
 
 
 MAX_MODEL_COUNT = 5
+LORA_MODEL_EXTS = ["pt", "ckpt", "safetensors"]
 lora_models = {}
 lora_models_dir = os.path.join(scripts.basedir(), "models/LoRA")
 os.makedirs(lora_models_dir, exist_ok=True)
 
 
 def update_lora_models():
-    global lora_models
-    res = {}
-    for filename in sorted(glob.iglob(os.path.join(lora_models_dir, '**/*.pt'), recursive=True)):
-        name = os.path.splitext(os.path.basename(filename))[0]
-        # Prevent a hypothetical "None.pt" from being listed.
-        if name != "None":
-            res[name + f"({sd_models.model_hash(filename)})"] = filename
-    lora_models = OrderedDict(**{"None": None}, **res)
+  global lora_models
+  res = {}
+  for ext in LORA_MODEL_EXTS:
+    for filename in sorted(glob.iglob(os.path.join(lora_models_dir, f"**/*.{ext}"), recursive=True)):
+      name = os.path.splitext(os.path.basename(filename))[0]
+      # Prevent a hypothetical "None.pt" from being listed.
+      if name != "None":
+        res[name + f"({sd_models.model_hash(filename)})"] = filename
+  lora_models = OrderedDict(**{"None": None}, **res)
 
 
 update_lora_models()

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -1,4 +1,6 @@
 import os
+import glob
+from collections import OrderedDict
 
 import torch
 
@@ -6,20 +8,36 @@ import modules.scripts as scripts
 import gradio as gr
 
 from modules.processing import Processed, process_images
+from modules import sd_models
+import modules.ui
 
 from scripts import lora_compvis
 
-try:
-  from tkinter import filedialog, Tk
-  tkinter_found = True
-except ImportError:
-  tkinter_found = False
+
+MAX_MODEL_COUNT = 5
+lora_models = {}
+lora_models_dir = os.path.join(scripts.basedir(), "models/LoRA")
+os.makedirs(lora_models_dir, exist_ok=True)
+
+
+def update_lora_models():
+    global lora_models
+    res = {}
+    for filename in sorted(glob.iglob(os.path.join(lora_models_dir, '**/*.pt'), recursive=True)):
+        name = os.path.splitext(os.path.basename(filename))[0]
+        # Prevent a hypothetical "None.pt" from being listed.
+        if name != "None":
+            res[name + f"({sd_models.model_hash(filename)})"] = filename
+    lora_models = OrderedDict(**{"None": None}, **res)
+
+
+update_lora_models()
 
 
 class Script(scripts.Script):
   def __init__(self) -> None:
     super().__init__()
-    self.latest_params = [(None, None, None)] * 5
+    self.latest_params = [(None, None, None)] * MAX_MODEL_COUNT
     self.latest_networks = []
     self.latest_model_hash = ""
 
@@ -28,45 +46,65 @@ class Script(scripts.Script):
 
   def show(self, is_img2img):
     return scripts.AlwaysVisible
-  
-  def get_any_file_path(self, file_path=''):
-    if not tkinter_found:
-      return "tkinter not found"
-
-    current_file_path = file_path
-    # print(f'current file path: {current_file_path}')
-
-    root = Tk()
-    root.wm_attributes('-topmost', 1)
-    root.withdraw()
-    file_path = filedialog.askopenfilename()
-    root.destroy()
-
-    if file_path == '':
-        file_path = current_file_path
-
-    return file_path
 
   def ui(self, is_img2img):
     ctrls = []
+    model_dropdowns = []
+    self.infotext_fields = []
     with gr.Group():
       with gr.Accordion('Additional Networks', open=False):
         enabled = gr.Checkbox(label='Enable', value=False)
         ctrls.append(enabled)
+        self.infotext_fields.append((enabled, "AddNet Enabled"))
 
-        for i in range(5):
+        for i in range(MAX_MODEL_COUNT):
           with gr.Row():
             module = gr.Dropdown(["LoRA"], label=f"Network module {i+1}", value="LoRA")
-            model = gr.Textbox(label=f"Model {i+1}")
-            
-            model_file = gr.Button(
-                '📂', elem_id='open_folder'
-            )
-            model_file.click(self.get_any_file_path, inputs=model, outputs=model)
-            weight = gr.Slider(label=f"Weight {i+1}", value=1, minimum=-1.0, maximum=2.0, step=.05)
+            model = gr.Dropdown(list(lora_models.keys()),
+                                          label=f"Model {i+1}",
+                                          value="None")
+
+            weight = gr.Slider(label=f"Weight {i+1}", value=1.0, minimum=-1.0, maximum=2.0, step=.05)
           ctrls.extend((module, model, weight))
+          model_dropdowns.append(model)
+
+          self.infotext_fields.extend([
+              (module, f"AddNet Module {i+1}"),
+              (model, f"AddNet Model {i+1}"),
+              (weight, f"AddNet Weight {i+1}"),
+          ])
+
+        def refresh_all_models(*dropdowns):
+          update_lora_models()
+          updates = []
+          for dd in dropdowns:
+            if dd in lora_models:
+              selected = dd
+            else:
+              selected = "None"
+            update = gr.Dropdown.update(value=selected, choices=list(lora_models.keys()))
+            updates.append(update)
+          return updates
+
+        refresh_models = gr.Button(value='Refresh models')
+        refresh_models.click(refresh_all_models, inputs=model_dropdowns, outputs=model_dropdowns)
+        ctrls.append(refresh_models)
 
     return ctrls
+
+  def set_infotext_fields(self, p, params):
+    p.extra_generation_params.update({
+        "AddNet Enabled": True
+    })
+    for i, t in enumerate(params):
+      module, model, weight = t
+      if model is None or model == "None" or len(model) == 0 or weight == 0:
+        continue
+      p.extra_generation_params.update({
+        f"AddNet Module {i+1}": module,
+        f"AddNet Model {i+1}": model,
+        f"AddNet Weight {i+1}": weight,
+       })
 
   def process(self, p, *args):
     unet = p.sd_model.model.diffusion_model
@@ -106,28 +144,35 @@ class Script(scripts.Script):
       self.latest_model_hash = p.sd_model.sd_model_hash
 
       for module, model, weight in self.latest_params:
-        if model is None or len(model) == 0:
+        if model is None or model == "None" or len(model) == 0:
           continue
         if weight == 0:
           print(f"ignore because weight is 0: {model}")
           continue
 
-        if model.startswith("\"") and model.endswith("\""):             # trim '"' at start/end
-          model = model[1:-1]
-        if not os.path.exists(model):
-          print(f"file not found: {model}")
+        model_path = lora_models.get(model, None)
+        if model_path is None:
+          raise RuntimeError(f"model not found: {model}")
+          continue
+
+        if model_path.startswith("\"") and model_path.endswith("\""):             # trim '"' at start/end
+          model_path = model_path[1:-1]
+        if not os.path.exists(model_path):
+          print(f"file not found: {model_path}")
           continue
 
         print(f"{module} weight: {weight}, model: {model}")
         if module == "LoRA":
-          if os.path.splitext(model)[1] == '.safetensors':
+          if os.path.splitext(model_path)[1] == '.safetensors':
             from safetensors.torch import load_file
-            du_state_dict = load_file(model)
+            du_state_dict = load_file(model_path)
           else:
-            du_state_dict = torch.load(model, map_location='cpu')
+            du_state_dict = torch.load(model_path, map_location='cpu')
 
           network, info = lora_compvis.create_network_and_apply_compvis(du_state_dict, weight, text_encoder, unet)
           print(f"LoRA model {model} loaded: {info}")
           self.latest_networks.append((network, model))
       if len(self.latest_networks) > 0:
         print("setting (or sd model) changed. new networks created.")
+
+    self.set_infotext_fields(p, self.latest_params)

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -95,18 +95,21 @@ class Script(scripts.Script):
     return ctrls
 
   def set_infotext_fields(self, p, params):
-    p.extra_generation_params.update({
-        "AddNet Enabled": True
-    })
+    found_any = False
     for i, t in enumerate(params):
       module, model, weight = t
       if model is None or model == "None" or len(model) == 0 or weight == 0:
         continue
+      found_any = True
       p.extra_generation_params.update({
         f"AddNet Module {i+1}": module,
         f"AddNet Model {i+1}": model,
         f"AddNet Weight {i+1}": weight,
        })
+    if found_any:
+      p.extra_generation_params.update({
+        "AddNet Enabled": True
+      })
 
   def process(self, p, *args):
     unet = p.sd_model.model.diffusion_model


### PR DESCRIPTION
This saves the hash/weights of all LoRA models in the infotext so they can be restored with the `Send to txt2img` buttons

To do this in a reasonable manner, the way models are loaded has been changed to act like hypernetworks, now they are stored in the `models/LoRA` folder and refreshed through the UI