### PR TITLE
Model metadata editor and hashing update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 models/
+/hashes.json

--- a/javascript/additional_networks.js
+++ b/javascript/additional_networks.js
@@ -1,0 +1,11 @@
+function addnet_switch_to_txt2img(){
+  switch_to_txt2img();
+  setTimeout(function() { gradioApp().getElementById("additional_networks_txt2img").scrollIntoView(); }, 100);
+  return args_to_array(arguments);
+}
+
+function addnet_switch_to_img2img(){
+  switch_to_img2img();
+  setTimeout(function() { gradioApp().getElementById("additional_networks_img2img").scrollIntoView(); }, 100);
+  return args_to_array(arguments);
+}

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -604,14 +604,14 @@ Requested path was: {f}
 
     def refresh_metadata(module, model):
       if model == "None":
-        return {}, None, "", "", "", 0, "", "", "", ""
+        return {"info": "No model loaded."}, None, "", "", "", "", 0, "", "", "", ""
 
       model_path = lora_models.get(model, None)
       if model_path is None:
-        return {}, None, "", "", "", 0, "", "", "", ""
+        return {"info": f"Model path not found: {model}"}, None, "", "", "", "", 0, "", "", "", ""
 
       if os.path.splitext(model_path)[1] != ".safetensors":
-        return {}, None, "", "", "", 0, "", "", "", ""
+        return {"info": f"Model is not in .safetensors format."}, None, "", "", "", "", 0, "", "", "", ""
 
       metadata = read_lora_metadata(model_path, module)
 

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -54,7 +54,13 @@ LORA_TRAIN_METADATA_NAMES = {
     "ss_max_bucket_reso": "Max bucket reso.",
     "ss_seed": "Seed",
     "ss_sd_model_name": "SD model name",
-    "ss_vae_name": "VAE name"
+    "ss_vae_name": "VAE name",
+    "ss_training_started_at": "Training started at",
+    "ss_output_name": "Output name",
+    "ss_session_id": "Session ID",
+    "ss_dataset_dirs": "Dataset dirs",
+    "ss_reg_dataset_dirs": "Reg. dataset dirs",
+    "ss_keep_tokens": "Keep tokens",
 }
 
 
@@ -373,18 +379,18 @@ def on_ui_tabs():
         training_params = "No training parameters found."
         metadata = {}
       else:
-        training_params = {k: v for k, v in metadata.items() if k in LORA_TRAIN_METADATA_NAMES}
+        training_params = {k: v for k, v in metadata.items() if k.startswith("ss_")}
         if not training_params:
           training_params = "No training parameters found."
 
-      cover_image = metadata.get("ss_md_cover_image", None)
+      cover_image = metadata.get("ssmd_cover_image", None)
       if cover_image == "None":
         cover_image = None
-      display_name = metadata.get("ss_md_display_name", "")
-      keywords = metadata.get("ss_md_keywords", "")
-      description = metadata.get("ss_md_description", "")
-      rating = int(metadata.get("ss_md_rating", "0"))
-      tags = metadata.get("ss_md_tags", "")
+      display_name = metadata.get("ssmd_display_name", "")
+      keywords = metadata.get("ssmd_keywords", "")
+      description = metadata.get("ssmd_description", "")
+      rating = int(metadata.get("ssmd_rating", "0"))
+      tags = metadata.get("ssmd_tags", "")
       return training_params, cover_image, display_name, keywords, description, rating, tags
 
     model.change(refresh_metadata, inputs=[module, model], outputs=[metadata_view, cover_image, display_name, keywords, description, rating, tags])
@@ -398,12 +404,12 @@ def on_ui_tabs():
         return f"file not found: {model_path}"
 
       updates = {
-        "ss_md_cover_image": None,
-        "ss_md_display_name": display_name,
-        "ss_md_keywords": keywords,
-        "ss_md_description": description,
-        "ss_md_rating": rating,
-        "ss_md_tags": tags
+        "ssmd_cover_image": None,
+        "ssmd_display_name": display_name,
+        "ssmd_keywords": keywords,
+        "ssmd_description": description,
+        "ssmd_rating": rating,
+        "ssmd_tags": tags
       }
 
       write_lora_metadata(model_path, module, updates)

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -692,8 +692,6 @@ def on_ui_settings():
     shared.opts.add_option("additional_networks_sort_models_by", shared.OptionInfo("name", "Sort LoRA models by", gr.Radio, {"choices": ["name", "date", "path name"]}, section=section))
     shared.opts.add_option("additional_networks_model_name_filter", shared.OptionInfo("", "LoRA model name filter", section=section))
     shared.opts.add_option("additional_networks_xy_grid_model_metadata", shared.OptionInfo("", "Metadata to show in XY-Grid label for Model axes, comma-separated (example: \"ss_learning_rate, ss_num_epochs\")", section=section))
-    shared.opts.add_option("additional_networks_use_old_model_hashing_algorithm", shared.OptionInfo(False, "Use the old hashing algorithm for model hashes/infotext restoration", section=section))
-    shared.opts.add_option("additional_networks_force_recalculate_hashes", shared.OptionInfo(False, "Update all model files with new hashes. WARNING: This will take a long time, disable after it's done.", section=section))
     shared.opts.add_option("additional_networks_back_up_model_when_saving", shared.OptionInfo(True, "Makes a backup copy of the model being edited when saving its metadata.", section=section))
 
 

--- a/scripts/safetensors_hack.py
+++ b/scripts/safetensors_hack.py
@@ -87,7 +87,7 @@ def legacy_hash_file(filename):
       return sd_models.model_hash(filename)
 
 
-DTYPES = {"F32": torch.float32, "F16": torch.float16}
+DTYPES = {"F32": torch.float32, "F16": torch.float16, "BF16": torch.bfloat16}
 
 
 def create_tensor(storage, info, offset):

--- a/scripts/safetensors_hack.py
+++ b/scripts/safetensors_hack.py
@@ -1,0 +1,91 @@
+import io
+import os
+import mmap
+import torch
+import json
+import hashlib
+import safetensors
+import safetensors.torch
+
+from modules import sd_models
+
+def read_metadata(filename):
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+            metadata_bytes = m.read(n)
+            metadata = json.loads(metadata_bytes)
+
+    return metadata.get("__metadata__", {})
+
+
+def load_file(filename, device):
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+            metadata_bytes = m.read(n)
+            metadata = json.loads(metadata_bytes)
+
+    size = os.stat(filename).st_size
+    storage = torch._UntypedStorage.from_file(filename, False, size)
+    offset = n + 8
+    md = metadata.get("__metadata__", {})
+    return {name: create_tensor(storage, info, offset) for name, info in metadata.items() if name != "__metadata__"}, md
+
+
+def hash_file(filename):
+    hash_sha256 = hashlib.sha256()
+    blksize = 1024 * 1024
+
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+
+    with open(filename, mode="rb") as file_obj:
+        offset = n + 8
+        file_obj.seek(offset)
+        for chunk in iter(lambda: file_obj.read(blksize), b""):
+            hash_sha256.update(chunk)
+
+    return hash_sha256.hexdigest()
+
+
+def legacy_hash_file(filename):
+    hash_sha256 = hashlib.sha256()
+
+    metadata = read_metadata(filename)
+
+    # For compatibility with legacy models: This replicates the behavior of
+    # sd_models.model_hash as if there were no user-specified metadata in the
+    # .safetensors file. That leaves the training parameters, which are
+    # immutable. It is important the hash does not include the embedded user
+    # metadata as that would mean the hash changes every time the user updates
+    # the name/description/etc. The new hashing method fixes this problem by
+    # only hashing the region of the file containing the tensors.
+    if any(not k.startswith("ss_") for k in metadata):
+      # Strip the user metadata, re-serialize the file as if it were freshly
+      # created from sd-scripts, and hash that with model_hash's behavior.
+      tensors, metadata = load_file(filename, "cpu")
+      metadata = {k: v for k, v in metadata.items() if k.startswith("ss_")}
+      model_bytes = safetensors.torch.save(tensors, metadata)
+
+      hash_sha256.update(model_bytes[0x100000:0x110000])
+      return hash_sha256.hexdigest()[0:8]
+    else:
+      # This should work fine with model_hash since when the legacy hashing
+      # method was being used the user metadata system hadn't been implemented
+      # yet.
+      return sd_models.model_hash(filename)
+
+
+DTYPES = {"F32": torch.float32, "F16": torch.float16}
+
+
+def create_tensor(storage, info, offset):
+    dtype = DTYPES[info["dtype"]]
+    shape = info["shape"]
+    start, stop = info["data_offsets"]
+    return torch.asarray(storage[start + offset : stop + offset], dtype=torch.uint8).view(dtype=dtype).reshape(shape).clone().detach()

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+#additional_networks_cover_image,
+#additional_networks_cover_image > .h-60,
+#additional_networks_cover_image > .h-60 > div,
+#additional_networks_cover_image > .h-60 > div > img
+{
+    height: 480px !important;
+    max-height: 480px !important;
+    min-height: 480px !important;
+}

--- a/style.css
+++ b/style.css
@@ -7,3 +7,12 @@
     max-height: 480px !important;
     min-height: 480px !important;
 }
+
+[id^=additional_networks_send_to_] {
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    max-width: 2.5em;
+    min-width: 2.5em;
+    height: 2.4em;
+}


### PR DESCRIPTION
Adds a metadata editor for LoRA models. Now people won't have to put the instructions or cover images in separate files where they can get lost. It can also save ratings, activation keywords and tags, for a future model browser component

Also updates the hashing methodology to be more resiliant like webui's new algorithm. This hash change should *not* affect old seeds since the "legacy" hash is also calculated for each model upfront, unlike what webui is currently doing (only calculating/caching the hash if a model is loaded)

![](https://user-images.githubusercontent.com/24979496/213355346-92df57ed-572b-4ece-8109-7d64bbc0ed1f.png)

Some deficits:
- Getting the hash for all models takes a very long time (about 15 minutes on an HDD with 1500 files), but I'm not sure what else to do when it comes to keeping backward compatibility for seeds. It's probably faster with an SSD though, the number of hashing threads is user-configurable
- After the hashes are calculated they're cached so future startups are instant. But if the directory structure of the LoRAs folder is changed without the models having an embedded hash, all the hashes have to be recalculated. This can be solved for future models by precalculating the hash with `sd-scripts` first
- By nature of the hashing technique, it requires the whole file to be serialized so the tensors region can be scanned through, so in practice new models have to be serialized twice to get and save the hash to the metadata
  + I tried a method that hashes the `torch.Tensor`s in-memory, alleviating the need for serializing the extra time, but it was 80% slower than hashing the raw file's bytes. Again, might be different if a SSD is used, but it's a difference between 15 minutes and 40 minutes, and the two types of hashes are incompatible with each other
- Updating metadata is an expensive operation due to the nature of the safetensors format and the big files. Ideally it should be done when an author is editing their own models for distribution so it's only ever done once
- Only one cover image is supported right now because `gr.Gallery()` doesn't support uploading: https://github.com/gradio-app/gradio/issues/1379
- Model ratings are saved to the model file, but of course ratings are subjective, not a property of the model itself. Maybe keeping a separate database for ratings would be better