### PR TITLE
Improve hashing algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 models/
+/hashes.json

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -5,7 +5,10 @@ import json
 import stat
 import sys
 import inspect
+import re
+import tqdm
 from collections import OrderedDict
+from multiprocessing.pool import ThreadPool as Pool
 
 import torch
 
@@ -14,10 +17,10 @@ from modules import shared, script_callbacks
 import gradio as gr
 
 from modules.processing import Processed, process_images
-from modules import sd_models
+from modules import sd_models, hashes
 import modules.ui
 
-from scripts import lora_compvis
+from scripts import lora_compvis, safetensors_hack
 
 
 LORA_TRAIN_METADATA_NAMES = {
@@ -31,6 +34,7 @@ LORA_TRAIN_METADATA_NAMES = {
     "ss_num_reg_images": "# of reg images",
     "ss_num_batches_per_epoch": "Batches per epoch",
     "ss_num_epochs": "Total epochs",
+    "ss_epoch": "Epoch",
     "ss_batch_size_per_device": "Batch size/device",
     "ss_total_batch_size": "Total batch size",
     "ss_gradient_checkpointing": "Gradient checkpointing",
@@ -67,11 +71,28 @@ LORA_TRAIN_METADATA_NAMES = {
 
 MAX_MODEL_COUNT = 5
 LORA_MODEL_EXTS = [".pt", ".ckpt", ".safetensors"]
-lora_models = {}      # "My_Lora(abcd1234)" -> C:/path/to/model.safetensors
-lora_model_names = {}  # "my_lora" -> "My_Lora(abcd1234)"
+re_legacy_hash = re.compile("\(([0-9a-f]{8})\)$") # matches 8-character hashes, new hash has 12 characters
+lora_models = {}       # "My_Lora(abcdef123456)" -> "C:/path/to/model.safetensors"
+lora_model_names = {}  # "my_lora" -> "My_Lora(My_Lora(abcdef123456)"
+legacy_model_names = {}
 lora_models_dir = os.path.join(scripts.basedir(), "models/lora")
 axis_params = [{}] * MAX_MODEL_COUNT
 os.makedirs(lora_models_dir, exist_ok=True)
+
+
+def get_model_list(module, model, model_dir, sort_by):
+    if model_dir == "":
+        # Get list of models with same folder as this one
+        model_path = lora_models.get(model, None)
+        if model_path is None:
+            return []
+        model_dir = os.path.dirname(model_path)
+
+    if not os.path.isdir(model_dir):
+        return []
+
+    found = get_all_models(sort_by, "", model_dir)
+    return found.keys()
 
 
 def update_axis_params(i, module, model):
@@ -169,81 +190,204 @@ def traverse_all_files(curr_path, model_list):
   return model_list
 
 
-def get_all_models(sort_by, filter_by, path):
+def get_model_hash(metadata, filename):
+  if not metadata:
+    return hashes.calculate_sha256(filename)
+
+  if "sshs_model_hash" in metadata:
+    return metadata["sshs_model_hash"]
+
+  return safetensors_hack.hash_file(filename)
+
+
+def get_legacy_hash(metadata, filename):
+  if not metadata:
+    return sd_models.model_hash(filename)
+
+  if "sshs_legacy_hash" in metadata:
+    return metadata["sshs_legacy_hash"]
+
+  return safetensors_hack.legacy_hash_file(filename)
+
+
+import filelock
+cache_filename = os.path.join(scripts.basedir(), "hashes.json")
+cache_data = None
+
+def cache(subsection):
+    global cache_data
+
+    if cache_data is None:
+        with filelock.FileLock(cache_filename+".lock"):
+            if not os.path.isfile(cache_filename):
+                cache_data = {}
+            else:
+                with open(cache_filename, "r", encoding="utf8") as file:
+                    cache_data = json.load(file)
+
+    s = cache_data.get(subsection, {})
+    cache_data[subsection] = s
+
+    return s
+
+
+def dump_cache():
+    with filelock.FileLock(cache_filename+".lock"):
+        with open(cache_filename, "w", encoding="utf8") as file:
+            json.dump(cache_data, file, indent=4)
+
+
+
+def is_safetensors(filename):
+    return os.path.splitext(filename)[1] == ".safetensors"
+
+
+def get_model_rating(filename):
+  if not is_safetensors(filename):
+    return 0
+
+  metadata = safetensors_hack.read_metadata(filename)
+  return int(metadata.get("ssmd_rating", "0"))
+
+
+def hash_model_file(finfo):
+  filename = finfo[0]
+  stat = finfo[1]
+  name = os.path.splitext(os.path.basename(filename))[0]
+
+  # Prevent a hypothetical "None.pt" from being listed.
+  if name != "None":
+    metadata = None
+
+    cached = cache("hashes").get(filename, None)
+    if cached is None or stat.st_mtime != cached["mtime"]:
+      if metadata is None and is_safetensors(filename):
+        metadata = safetensors_hack.read_metadata(filename)
+      model_hash = get_model_hash(metadata, filename)
+      legacy_hash = get_legacy_hash(metadata, filename)
+    else:
+      model_hash = cached["model"]
+      legacy_hash = cached["legacy"]
+
+  return {"model": model_hash, "legacy": legacy_hash, "fileinfo": finfo}
+
+
+def get_all_models(paths, sort_by, filter_by):
+  fileinfos = []
+  for path in paths:
+    if os.path.isdir(path):
+      fileinfos += traverse_all_files(path, [])
+
+  print("[AddNet] Updating model hashes...")
+  data = []
+  thread_count = max(1, int(shared.opts.data.get("additional_networks_hash_thread_count", 1)))
+  p = Pool(processes=thread_count)
+  with tqdm.tqdm(total=len(fileinfos)) as pbar:
+      for res in p.imap_unordered(hash_model_file, fileinfos):
+          pbar.update()
+          data.append(res)
+  p.close()
+
+  cache_hashes = cache("hashes")
+
   res = OrderedDict()
-  fileinfos = traverse_all_files(path, [])
+  res_legacy = OrderedDict()
   filter_by = filter_by.strip(" ")
   if len(filter_by) != 0:
-    fileinfos = [x for x in fileinfos if filter_by.lower() in os.path.basename(x[0]).lower()]
+    data = [x for x in data if filter_by.lower() in os.path.basename(x["fileinfo"][0]).lower()]
   if sort_by == "name":
-    fileinfos = sorted(fileinfos, key=lambda x: os.path.basename(x[0]))
+    data = sorted(data, key=lambda x: os.path.basename(x["fileinfo"][0]))
   elif sort_by == "date":
-    fileinfos = sorted(fileinfos, key=lambda x: -x[1].st_mtime)
+    data = sorted(data, key=lambda x: -x["fileinfo"][1].st_mtime)
   elif sort_by == "path name":
-    fileinfos = sorted(fileinfos)
+    data = sorted(data)
+  elif sort_by == "rating":
+    data = sorted(data, key=lambda x: get_model_rating(x["fileinfo"][0]), reverse=True)
 
-  for finfo in fileinfos:
+  for result in data:
+    finfo = result["fileinfo"]
     filename = finfo[0]
+    stat = finfo[1]
+    model_hash = result["model"]
+    legacy_hash = result["legacy"]
+
     name = os.path.splitext(os.path.basename(filename))[0]
+
     # Prevent a hypothetical "None.pt" from being listed.
     if name != "None":
-      res[name + f"({sd_models.model_hash(filename)})"] = filename
+      full_name = name + f"({model_hash[0:12]})"
+      res[full_name] = filename
+      res_legacy[legacy_hash] = full_name
+      cache_hashes[filename] = {"model": model_hash, "legacy": legacy_hash, "mtime": stat.st_mtime}
 
-  return res
+  return res, res_legacy
 
 
 def find_closest_lora_model_name(search: str):
-  if not search:
-    return None
-  if search in lora_models:
-    return search
-  search = search.lower()
-  if search in lora_model_names:
-    return lora_model_names.get(search)
-  applicable = [name for name in lora_model_names.keys() if search in name.lower()]
-  if not applicable:
-    return None
-  applicable = sorted(applicable, key=lambda name: len(name))
-  return lora_model_names[applicable[0]]
+    print(f"SEARCH: {search}")
+    if not search or search == "None":
+        return None
+
+    # Match name and hash, case-sensitive
+    # "MyModel-epoch00002(abcdef123456)"
+    if search in lora_models:
+        print(f"Found case-sensitive")
+        return search
+
+    # Match full name, case-insensitive
+    # "mymodel-epoch00002"
+    search = search.lower()
+    if search in lora_model_names:
+        print(f"Found full name case-insensitive")
+        return lora_model_names.get(search)
+
+    # Match legacy hash (8 characters)
+    # "MyModel(abcd1234)"
+    result = re_legacy_hash.search(search)
+    if result is not None:
+        model_hash = result.group(1)
+        print(f"Legacy hash: {model_hash}")
+        if model_hash in legacy_model_names:
+            new_model_name = legacy_model_names[model_hash]
+            print(f"Found from legacy: {new_model_name}")
+            return new_model_name
+
+    # Use any model with the search term as the prefix, case-insensitive, sorted
+    # by name length
+    # "mymodel"
+    applicable = [name for name in lora_model_names.keys() if search in name.lower()]
+    print(f"Search results: {applicable}")
+    if not applicable:
+        return None
+    applicable = sorted(applicable, key=lambda name: len(name))
+    return lora_model_names[applicable[0]]
 
 
 def update_lora_models():
-  global lora_models, lora_model_names
-  res = OrderedDict()
+  global lora_models, lora_model_names, legacy_model_names
   paths = [lora_models_dir]
   extra_lora_path = shared.opts.data.get("additional_networks_extra_lora_path", None)
   if extra_lora_path and os.path.exists(extra_lora_path):
     paths.append(extra_lora_path)
-  for path in paths:
-    sort_by = shared.opts.data.get("additional_networks_sort_models_by", "name")
-    filter_by = shared.opts.data.get("additional_networks_model_name_filter", "")
-    found = get_all_models(sort_by, filter_by, path)
-    res = {**found, **res}
+
+  sort_by = shared.opts.data.get("additional_networks_sort_models_by", "name")
+  filter_by = shared.opts.data.get("additional_networks_model_name_filter", "")
+  res, res_legacy = get_all_models(paths, sort_by, filter_by)
+
   lora_models = OrderedDict(**{"None": None}, **res)
   lora_model_names = {}
+
   for name_and_hash, filename in lora_models.items():
-    if filename == None:
-      continue
-    name = os.path.splitext(os.path.basename(filename))[0].lower()
-    lora_model_names[name] = name_and_hash
+      if filename == None:
+          continue
+      name = os.path.splitext(os.path.basename(filename))[0].lower()
+      lora_model_names[name] = name_and_hash
+
+  legacy_model_names = res_legacy
+  dump_cache()
 
 
 update_lora_models()
-
-
-def get_model_list(module, model, model_dir, sort_by):
-    if model_dir == "":
-        # Get list of models with same folder as this one
-        model_path = lora_models.get(model, None)
-        if model_path is None:
-            return f"file not found: {model_path}"
-        model_dir = os.path.dirname(model_path)
-
-    if not os.path.isdir(model_dir):
-        return f"directory not found: {model_dir}"
-
-    found = get_all_models(sort_by, "", model_dir)
-    return found.keys()
 
 
 class Script(scripts.Script):
@@ -453,9 +597,13 @@ def on_ui_settings():
   shared.opts.add_option("additional_networks_model_name_filter", shared.OptionInfo("", "LoRA model name filter", section=section))
   shared.opts.add_option("additional_networks_xy_grid_model_metadata", shared.OptionInfo(
       "", "Metadata to show in XY-Grid label for Model axes, comma-separated (example: \"ss_learning_rate, ss_num_epochs\")", section=section))
+  shared.opts.add_option("additional_networks_hash_thread_count", shared.OptionInfo(1, "# of threads to use for hash calculation (increase if using an SSD)", section=section))
 
 
 def on_infotext_pasted(infotext, params):
+  if "AddNet Enabled" not in params:
+    params["AddNet Enabled"] = "False"
+
   for i in range(MAX_MODEL_COUNT):
     if f"AddNet Module {i+1}" not in params:
       params[f"AddNet Module {i+1}"] = "LoRA"
@@ -463,6 +611,10 @@ def on_infotext_pasted(infotext, params):
       params[f"AddNet Model {i+1}"] = "None"
     if f"AddNet Weight {i+1}" not in params:
       params[f"AddNet Weight {i+1}"] = "0"
+
+    # Convert potential legacy name/hash to new format
+    params[f"AddNet Model {i+1}"] = str(find_closest_lora_model_name(params[f"AddNet Model {i+1}"]))
+
 
 
 script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -334,21 +334,18 @@ def get_all_models(paths, sort_by, filter_by):
 
 
 def find_closest_lora_model_name(search: str):
-    print(f"SEARCH: {search}")
     if not search or search == "None":
         return None
 
     # Match name and hash, case-sensitive
     # "MyModel-epoch00002(abcdef123456)"
     if search in lora_models:
-        print(f"Found case-sensitive")
         return search
 
     # Match full name, case-insensitive
     # "mymodel-epoch00002"
     search = search.lower()
     if search in lora_model_names:
-        print(f"Found full name case-insensitive")
         return lora_model_names.get(search)
 
     # Match legacy hash (8 characters)
@@ -356,17 +353,14 @@ def find_closest_lora_model_name(search: str):
     result = re_legacy_hash.search(search)
     if result is not None:
         model_hash = result.group(1)
-        print(f"Legacy hash: {model_hash}")
         if model_hash in legacy_model_names:
             new_model_name = legacy_model_names[model_hash]
-            print(f"Found from legacy: {new_model_name}")
             return new_model_name
 
     # Use any model with the search term as the prefix, case-insensitive, sorted
     # by name length
     # "mymodel"
     applicable = [name for name in lora_model_names.keys() if search in name.lower()]
-    print(f"Search results: {applicable}")
     if not applicable:
         return None
     applicable = sorted(applicable, key=lambda name: len(name))

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -91,7 +91,7 @@ def get_model_list(module, model, model_dir, sort_by):
     if not os.path.isdir(model_dir):
         return []
 
-    found = get_all_models(sort_by, "", model_dir)
+    found, _ = get_all_models([model_dir], sort_by, "")
     return found.keys()
 
 

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -191,7 +191,7 @@ def traverse_all_files(curr_path, model_list):
 
 
 def get_model_hash(metadata, filename):
-  if not metadata:
+  if metadata is None:
     return hashes.calculate_sha256(filename)
 
   if "sshs_model_hash" in metadata:
@@ -201,7 +201,7 @@ def get_model_hash(metadata, filename):
 
 
 def get_legacy_hash(metadata, filename):
-  if not metadata:
+  if metadata is None:
     return sd_models.model_hash(filename)
 
   if "sshs_legacy_hash" in metadata:

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -308,7 +308,7 @@ def get_all_models(paths, sort_by, filter_by):
   elif sort_by == "date":
     data = sorted(data, key=lambda x: -x["fileinfo"][1].st_mtime)
   elif sort_by == "path name":
-    data = sorted(data)
+    data = sorted(data, key=lambda x: x["fileinfo"][0])
   elif sort_by == "rating":
     data = sorted(data, key=lambda x: get_model_rating(x["fileinfo"][0]), reverse=True)
   elif sort_by == "has user metadata":

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -552,9 +552,7 @@ def read_lora_metadata(model_path, module):
   metadata = None
   if module == "LoRA":
     if os.path.splitext(model_path)[1] == '.safetensors':
-      from safetensors.torch import safe_open
-      with safe_open(model_path, framework="pt") as f:
-        metadata = f.metadata()
+      metadata = safetensors_hack.read_metadata(model_path)
 
   return metadata
 

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -250,6 +250,14 @@ def get_model_rating(filename):
   return int(metadata.get("ssmd_rating", "0"))
 
 
+def has_user_metadata(filename):
+  if not is_safetensors(filename):
+    return False
+
+  metadata = safetensors_hack.read_metadata(filename)
+  return any(k.startswith("ssmd_") for k in metadata.keys())
+
+
 def hash_model_file(finfo):
   filename = finfo[0]
   stat = finfo[1]
@@ -303,6 +311,8 @@ def get_all_models(paths, sort_by, filter_by):
     data = sorted(data)
   elif sort_by == "rating":
     data = sorted(data, key=lambda x: get_model_rating(x["fileinfo"][0]), reverse=True)
+  elif sort_by == "has user metadata":
+    data = sorted(data, key=lambda x: os.path.basename(x["fileinfo"][0]) if has_user_metadata(x["fileinfo"][0]) else "", reverse=True)
 
   for result in data:
     finfo = result["fileinfo"]
@@ -593,7 +603,7 @@ def on_ui_settings():
   shared.opts.add_option("additional_networks_extra_lora_path", shared.OptionInfo(
       "", "Extra path to scan for LoRA models (e.g. training output directory)", section=section))
   shared.opts.add_option("additional_networks_sort_models_by", shared.OptionInfo(
-      "name", "Sort LoRA models by", gr.Radio, {"choices": ["name", "date", "path name"]}, section=section))
+      "name", "Sort LoRA models by", gr.Radio, {"choices": ["name", "date", "path name", "rating", "has user metadata"]}, section=section))
   shared.opts.add_option("additional_networks_model_name_filter", shared.OptionInfo("", "LoRA model name filter", section=section))
   shared.opts.add_option("additional_networks_xy_grid_model_metadata", shared.OptionInfo(
       "", "Metadata to show in XY-Grid label for Model axes, comma-separated (example: \"ss_learning_rate, ss_num_epochs\")", section=section))

--- a/scripts/safetensors_hack.py
+++ b/scripts/safetensors_hack.py
@@ -9,6 +9,9 @@ import safetensors.torch
 
 from modules import sd_models
 
+# PyTorch 1.13 and later have _TypedStorage renamed to TypedStorage
+UntypedStorage = torch.storage.UntypedStorage if hasattr(torch.storage, 'UntypedStorage') else torch.storage._UntypedStorage
+
 def read_metadata(filename):
     """Reads the JSON metadata from a .safetensors file"""
     with open(filename, mode="r", encoding="utf8") as file_obj:
@@ -32,7 +35,7 @@ def load_file(filename, device):
             metadata = json.loads(metadata_bytes)
 
     size = os.stat(filename).st_size
-    storage = torch._UntypedStorage.from_file(filename, False, size)
+    storage = UntypedStorage.from_file(filename, False, size)
     offset = n + 8
     md = metadata.get("__metadata__", {})
     return {name: create_tensor(storage, info, offset) for name, info in metadata.items() if name != "__metadata__"}, md

--- a/scripts/safetensors_hack.py
+++ b/scripts/safetensors_hack.py
@@ -1,0 +1,99 @@
+import io
+import os
+import mmap
+import torch
+import json
+import hashlib
+import safetensors
+import safetensors.torch
+
+from modules import sd_models
+
+def read_metadata(filename):
+    """Reads the JSON metadata from a .safetensors file"""
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+            metadata_bytes = m.read(n)
+            metadata = json.loads(metadata_bytes)
+
+    return metadata.get("__metadata__", {})
+
+
+def load_file(filename, device):
+    """"Loads a .safetensors file without memory mapping that locks the model file.
+    Works around safetensors issue: https://github.com/huggingface/safetensors/issues/164"""
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+            metadata_bytes = m.read(n)
+            metadata = json.loads(metadata_bytes)
+
+    size = os.stat(filename).st_size
+    storage = torch._UntypedStorage.from_file(filename, False, size)
+    offset = n + 8
+    md = metadata.get("__metadata__", {})
+    return {name: create_tensor(storage, info, offset) for name, info in metadata.items() if name != "__metadata__"}, md
+
+
+def hash_file(filename):
+    """Hashes a .safetensors file using the new hashing method.
+    Only hashes the weights of the model."""
+    hash_sha256 = hashlib.sha256()
+    blksize = 1024 * 1024
+
+    with open(filename, mode="r", encoding="utf8") as file_obj:
+        with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as m:
+            header = m.read(8)
+            n = int.from_bytes(header, "little")
+
+    with open(filename, mode="rb") as file_obj:
+        offset = n + 8
+        file_obj.seek(offset)
+        for chunk in iter(lambda: file_obj.read(blksize), b""):
+            hash_sha256.update(chunk)
+
+    return hash_sha256.hexdigest()
+
+
+def legacy_hash_file(filename):
+    """Hashes a model file using the legacy `sd_models.model_hash()` method."""
+    hash_sha256 = hashlib.sha256()
+
+    metadata = read_metadata(filename)
+
+    # For compatibility with legacy models: This replicates the behavior of
+    # sd_models.model_hash as if there were no user-specified metadata in the
+    # .safetensors file. That leaves the training parameters, which are
+    # immutable. It is important the hash does not include the embedded user
+    # metadata as that would mean the hash could change every time the user
+    # updates the name/description/etc. The new hashing method fixes this
+    # problem by only hashing the region of the file containing the tensors.
+    if any(not k.startswith("ss_") for k in metadata):
+      # Strip the user metadata, re-serialize the file as if it were freshly
+      # created from sd-scripts, and hash that with model_hash's behavior.
+      tensors, metadata = load_file(filename, "cpu")
+      metadata = {k: v for k, v in metadata.items() if k.startswith("ss_")}
+      model_bytes = safetensors.torch.save(tensors, metadata)
+
+      hash_sha256.update(model_bytes[0x100000:0x110000])
+      return hash_sha256.hexdigest()[0:8]
+    else:
+      # This should work fine with model_hash since when the legacy hashing
+      # method was being used the user metadata system hadn't been implemented
+      # yet.
+      return sd_models.model_hash(filename)
+
+
+DTYPES = {"F32": torch.float32, "F16": torch.float16, "BF16": torch.bfloat16}
+
+
+def create_tensor(storage, info, offset):
+    """Creates a tensor without holding on to an open handle to the parent model
+    file."""
+    dtype = DTYPES[info["dtype"]]
+    shape = info["shape"]
+    start, stop = info["data_offsets"]
+    return torch.asarray(storage[start + offset : stop + offset], dtype=torch.uint8).view(dtype=dtype).reshape(shape).clone().detach()


### PR DESCRIPTION
Closes #48.

The new hash is 12 characters instead of 8 and is based on only the tensors of the file, which will not unintentionally change if the metadata is updated. PNG outputs with old hashes are detected by those with 8 characters in the hash instead of 12.

To support old seeds, this saves the hash created from `sd_models.model_hash()` in a cache like webui does. It also precalculates the new sha256 hash for models that don't have them embedded and saves them in the cache.