### PR TITLE
Add max-lora-count argument

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -1,0 +1,6 @@
+import os
+from modules import paths
+
+
+def preload(parser):
+    parser.add_argument("--max-lora-count", type=int, help="The maximum number of LoRA model can be used.", default=5)

--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -14,13 +14,13 @@ from modules import shared, script_callbacks
 import gradio as gr
 
 from modules.processing import Processed, process_images
-from modules import sd_models
+from modules import shared, sd_models
 import modules.ui
 
 from scripts import lora_compvis
 
 
-MAX_MODEL_COUNT = 5
+MAX_MODEL_COUNT = shared.cmd_opts.max_lora_count
 LORA_MODEL_EXTS = [".pt", ".ckpt", ".safetensors"]
 lora_models = {}      # "My_Lora(abcd1234)" -> C:/path/to/model.safetensors
 lora_model_names = {}  # "my_lora" -> "My_Lora(abcd1234)"


### PR DESCRIPTION
It is possible to use more than 5 LoRA models in the same time. The MAX_MODEL_COUNT is hardcoded as 5 making end-users hard to increase the amount of LoRA they can use. So I think it is a good idea to add "--max-lora-count" argument so that they can easily increase the amount of slot.