### PR TITLE
Allow additional networks to be swapped out between batches

### DIFF
--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -141,7 +141,7 @@ class Script(scripts.Script):
           f"AddNet Weight B {i+1}": weight_tenc,
       })
 
-  def process(self, p, *args):
+  def process_batch(self, p, *args, **kwargs):
     unet = p.sd_model.model.diffusion_model
     text_encoder = p.sd_model.cond_stage_model
 


### PR DESCRIPTION
I want to support this extension in https://github.com/space-nuko/stable-diffusion-webui-randomizer-keywords, so that you can randomly select a LoRA model between batches. However this script uses `process()` for setting the LoRAs so they will stay the same for all batches. This changes it to `process_batch()` so they can be swapped out between batches by my script.