### PR TITLE
Support "Send to img2img" button for additional networks parameters

### DIFF
--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -45,6 +45,7 @@ class Script(scripts.Script):
     paste_params.clear()
 
     self.infotext_fields = []
+    self.paste_field_names = []
 
     with gr.Group():
       with gr.Accordion('Additional Networks', open=False):
@@ -97,6 +98,9 @@ class Script(scripts.Script):
               (weight_unet, f"AddNet Weight A {i+1}"),
               (weight_tenc, f"AddNet Weight B {i+1}"),
           ])
+
+        for _, field_name in self.infotext_fields:
+          self.paste_field_names.append(field_name)
 
         def update_weight_sliders(separate, *sliders):
           updates = []


### PR DESCRIPTION
This fixes additional networks parameters not being copied with the "Send to img2img" button, it was a real pain to have to set them twice.

*Note:* Requires https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7818 to be merged first