### PR TITLE
Trim extra lora path

### DIFF
--- a/scripts/model_util.py
+++ b/scripts/model_util.py
@@ -309,7 +309,7 @@ def update_models():
   paths = [lora_models_dir]
   extra_lora_paths = util.split_path_list(shared.opts.data.get("additional_networks_extra_lora_path", ""))
   for path in extra_lora_paths:
-    path = path.strip()
+    path = path.lstrip()
     if os.path.isdir(path):
       paths.append(path)
 

--- a/scripts/model_util.py
+++ b/scripts/model_util.py
@@ -309,6 +309,7 @@ def update_models():
   paths = [lora_models_dir]
   extra_lora_paths = util.split_path_list(shared.opts.data.get("additional_networks_extra_lora_path", ""))
   for path in extra_lora_paths:
+    path = path.strip()
     if os.path.isdir(path):
       paths.append(path)
 


### PR DESCRIPTION
`additional_networks_extra_lora_path` に `path1, path2` のようにスペースが存在した場合にpath2の先頭にスペースが含まれてしまい、存在しないディレクトリとみなされてしまう問題の修正です。