### PR TITLE
Style fixes for Gradio 3.22

### DIFF
--- a/scripts/additional_networks.py
+++ b/scripts/additional_networks.py
@@ -8,6 +8,7 @@ from modules import shared, script_callbacks
 import gradio as gr
 
 import modules.ui
+from modules.ui_components import ToolButton, FormRow
 
 from scripts import lora_compvis, model_util, metadata_editor, xyz_grid_support
 from scripts.model_util import lora_models, MAX_MODEL_COUNT
@@ -59,7 +60,7 @@ class Script(scripts.Script):
           self.infotext_fields.append((separate_weights, "AddNet Separate Weights"))
 
         for i in range(MAX_MODEL_COUNT):
-          with gr.Row():
+          with FormRow(variant='compact'):
             module = gr.Dropdown(["LoRA"], label=f"Network module {i+1}", value="LoRA")
             model = gr.Dropdown(list(lora_models.keys()),
                                 label=f"Model {i+1}",
@@ -72,7 +73,7 @@ class Script(scripts.Script):
             # gradio since this button will exit the gr.Blocks context by the
             # time the metadata editor tab is created, so event handlers can't
             # be registered on it by then.
-            model_info = gr.Button(value=memo_symbol, elem_id=f"additional_networks_send_to_metadata_editor_{i}")
+            model_info = ToolButton(value=memo_symbol, elem_id=f"additional_networks_send_to_metadata_editor_{i}")
             model_info.click(fn=None, _js="addnet_send_to_metadata_editor", inputs=[module, model_path], outputs=[])
 
             module.change(lambda module, model, i=i: xyz_grid_support.update_axis_params(i, module, model), inputs=[module, model], outputs=[])

--- a/scripts/metadata_editor.py
+++ b/scripts/metadata_editor.py
@@ -380,7 +380,7 @@ def setup_ui(addnet_paste_params):
             with gr.Row():
               gr.HTML(f"Send to {tabname}:")
               for i in range(MAX_MODEL_COUNT):
-                send_to_button = gr.Button(value=keycap_symbols[i], elem_id=f"additional_networks_send_to_{tabname}_{i}")
+                send_to_button = ToolButton(value=keycap_symbols[i], elem_id=f"additional_networks_send_to_{tabname}_{i}")
                 send_to_button.click(fn=lambda modu, mod: (modu, model_util.find_closest_lora_model_name(mod) or "None"), inputs=[module, model], outputs=[addnet_paste_params[tabname][i]["module"], addnet_paste_params[tabname][i]["model"]])
                 send_to_button.click(fn=None,_js=f"addnet_switch_to_{tabname}", inputs=None, outputs=None)
 

--- a/style.css
+++ b/style.css
@@ -7,17 +7,3 @@
     max-height: 480px !important;
     min-height: 480px !important;
 }
-
-[id^=additional_networks_send_to_] {
-    display: flex;
-    align-content: center;
-    justify-content: center;
-    max-width: 2.5em;
-    min-width: 2.5em;
-    height: 2.4em;
-}
-
-
-[id^=additional_networks_send_to_metadata_editor_] {
-    transform: translateY(25%);
-}


### PR DESCRIPTION
Uses `FormRow` and `ToolButton` to make the UI more compact

<img width="668" alt="2023-03-21 18_28_41-Stable Diffusion - Chromium" src="https://user-images.githubusercontent.com/24979496/226756205-30a9e2e1-62e8-4bf8-881d-5d012621d331.png">
