### PR TITLE
use"{stable-diffusion-webui}/models/Lora" Dir to load model

### DIFF
--- a/scripts/model_util.py
+++ b/scripts/model_util.py
@@ -20,7 +20,10 @@ re_legacy_hash = re.compile("\(([0-9a-f]{8})\)$") # matches 8-character hashes, 
 lora_models = {}       # "My_Lora(abcdef123456)" -> "C:/path/to/model.safetensors"
 lora_model_names = {}  # "my_lora" -> "My_Lora(My_Lora(abcdef123456)"
 legacy_model_names = {}
-lora_models_dir = os.path.join(scripts.basedir(), "models/lora")
+#lora_models_dir = os.path.join(scripts.basedir(), "models/lora")
+# rootDir
+rootDir_temp = os.path.join(scripts.basedir(), "../..")
+lora_models_dir = os.path.join(rootDir_temp, "models/Lora")
 os.makedirs(lora_models_dir, exist_ok=True)
 
 


### PR DESCRIPTION
Most of the time, we use the SD root directory model to place Lora.
Through this change, the Lora model can be directly obtained from the SD root directory