### PR TITLE
Fix exception when a mask is used with hires fix disabled.

### DIFF
--- a/scripts/lora_compvis.py
+++ b/scripts/lora_compvis.py
@@ -617,6 +617,9 @@ class LoRANetworkCompvis(torch.nn.Module):
             mask_dic[mh * mw] = m
 
         for h, w in [(height, width), (hr_height, hr_width)]:
+            if not h or not w:
+                continue
+
             h = h // 8
             w = w // 8
             for i in range(4):


### PR DESCRIPTION
When hires fix isn't active, hr_upscale_to_x and hr_upscale_to_y are 0.  Skip creating a mask for that resolution so it doesn't try to create a 0x0 image.  Fixes #160:

```
Error running process_batch: stable-diffusion-webui\extensions\sd-webui-additional-networks\scripts\additional_networks.py Traceback (most recent call last):
  File "stable-diffusion-webui\modules\scripts.py", line 435, in process_batch
    script.process_batch(p, *script_args, **kwargs)
  File "stable-diffusion-webui\extensions\sd-webui-additional-networks\scripts\additional_networks.py", line 268, in process_batch
    network.set_mask(mask, height=p.height, width=p.width, hr_height=p.hr_upscale_to_y, hr_width=p.hr_upscale_to_x)
  File "stable-diffusion-webui\extensions\sd-webui-additional-networks\scripts\lora_compvis.py", line 623, in set_mask
    resize_add(h, w)
  File "stable-diffusion-webui\extensions\sd-webui-additional-networks\scripts\lora_compvis.py", line 615, in resize_add
    m = torch.nn.functional.interpolate(mask, (mh, mw), mode="bilinear")  # doesn't work in bf16
  File "stable-diffusion-webui\venv\lib\site-packages\torch\nn\functional.py", line 3995, in interpolate
    return torch._C._nn.upsample_bilinear2d(input, output_size, align_corners, scale_factors)
RuntimeError: Input and output sizes should be greater than 0, but got input (H: 299, W: 299) output (H: 0, W: 0)
```